### PR TITLE
Update brunch to 2.10.12 in project generator

### DIFF
--- a/installer/templates/phx_assets/brunch/package.json
+++ b/installer/templates/phx_assets/brunch/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "babel-brunch": "6.1.1",
-    "brunch": "2.10.9",
+    "brunch": "2.10.12",
     "clean-css-brunch": "2.10.0",
     "uglify-js-brunch": "2.10.0"
   }


### PR DESCRIPTION
Update brunch version to 2.10.12 in package.json. Previous version was 2.10.9. Fixes an issue with babel source mapping: https://github.com/brunch/brunch/issues/1635